### PR TITLE
#1012 - Removing type attribute from select elements

### DIFF
--- a/includes/option-types/form-builder/items/select/class-fw-option-type-form-builder-item-select.php
+++ b/includes/option-types/form-builder/items/select/class-fw-option-type-form-builder-item-select.php
@@ -210,7 +210,6 @@ class FW_Option_Type_Form_Builder_Item_Select extends FW_Option_Type_Form_Builde
 				'choices' => $choices,
 				'value'   => $value,
 				'attr'    => array(
-					'type' => 'select',
 					'name' => $item['shortcode'],
 					'id'   => 'id-' . fw_unique_increment(),
 				),


### PR DESCRIPTION
When using the W3C Validator having a type attribute in a select element causes it to fail so I have removed this.
https://github.com/ThemeFuse/Unyson/issues/1012
