### PR TITLE
more changes regarding the form items and their options

### DIFF
--- a/includes/option-types/form-builder/extends/class-fw-option-type-form-builder-item.php
+++ b/includes/option-types/form-builder/extends/class-fw-option-type-form-builder-item.php
@@ -67,12 +67,12 @@ abstract class FW_Option_Type_Form_Builder_Item extends FW_Option_Type_Builder_I
 	}
 
 	/**
-	 * Search in '/extensions/forms/{builder_type}/items/{item_type}/options/options.php'
+	 * Search in '/extensions/forms/{builder_type}/items/{item_type}/options.php'
 	 * @return array
 	 * @since 2.0.23
 	 */
 	final protected function get_extra_options() {
-		if ($extra_options = $this->locate_path( '/options/options.php', false )) {
+		if ($extra_options = $this->locate_path( '/options.php', false )) {
 			$extra_options = fw_get_variables_from_file($extra_options, array('options' => array()));
 			return $extra_options['options'];
 		} else {

--- a/includes/option-types/form-builder/items/checkboxes/class-fw-option-type-form-builder-item-checkboxes.php
+++ b/includes/option-types/form-builder/items/checkboxes/class-fw-option-type-form-builder-item-checkboxes.php
@@ -124,19 +124,6 @@ class FW_Option_Type_Form_Builder_Item_Checkboxes extends FW_Option_Type_Form_Bu
 				)
 			),
 			array(
-				'layout' => array(
-					'type'    => 'select',
-					'label'   => __( 'Field Layout', 'fw' ),
-					'desc'    => __( 'Select choice display layout', 'fw' ),
-					'choices' => array(
-						'one-column'    => __( 'One column', 'fw' ),
-						'two-columns'   => __( 'Two columns', 'fw' ),
-						'three-columns' => __( 'Three columns', 'fw' ),
-						'side-by-side'  => __( 'Side by side', 'fw' ),
-					),
-				)
-			),
-			array(
 				'info' => array(
 					'type'  => 'textarea',
 					'label' => __( 'Instructions for Users', 'fw' ),

--- a/includes/option-types/form-builder/items/checkboxes/options.php
+++ b/includes/option-types/form-builder/items/checkboxes/options.php
@@ -1,0 +1,15 @@
+<?php if (!defined('FW')) die('Forbidden');
+
+$options = array(
+  'layout' => array(
+    'type'    => 'select',
+    'label'   => __( 'Field Layout', 'fw' ),
+    'desc'    => __( 'Select choice display layout', 'fw' ),
+    'choices' => array(
+      'one-column'    => __( 'One column', 'fw' ),
+      'two-columns'   => __( 'Two columns', 'fw' ),
+      'three-columns' => __( 'Three columns', 'fw' ),
+      'side-by-side'  => __( 'Side by side', 'fw' ),
+    ),
+  )
+);

--- a/includes/option-types/form-builder/items/form-header-title/class-fw-option-type-form-builder-item-form-header-title.php
+++ b/includes/option-types/form-builder/items/form-header-title/class-fw-option-type-form-builder-item-form-header-title.php
@@ -56,18 +56,21 @@ class FW_Option_Type_Form_Builder_Item_Form_Header_Title extends FW_Option_Type_
 
 	private function get_options() {
 		return array(
-			'title'    => array(
-				'type'  => 'text',
-				'label' => __( 'Title', 'fw' ),
-				'desc'  => __( 'The title will be displayed on contact form header', 'fw' ),
-				'value' => '',
+			array(
+				'title'    => array(
+					'type'  => 'text',
+					'label' => __( 'Title', 'fw' ),
+					'desc'  => __( 'The title will be displayed on contact form header', 'fw' ),
+					'value' => '',
+				),
+				'subtitle' => array(
+					'type'  => 'textarea',
+					'label' => __( 'Subtitle', 'fw' ),
+					'desc'  => __( 'The form header subtitle text', 'fw' ),
+					'value' => '',
+				)
 			),
-			'subtitle' => array(
-				'type'  => 'textarea',
-				'label' => __( 'Subtitle', 'fw' ),
-				'desc'  => __( 'The form header subtitle text', 'fw' ),
-				'value' => '',
-			)
+			$this->get_extra_options()
 		);
 	}
 


### PR DESCRIPTION
Changes: 
* missing extra options in class-fw-option-type-form-builder-item-form-header-title.php
* removed layout from class-fw-option-type-form-builder-item-checkboxes.php
* layout option is now located in options.php
* Fix "normal" shortcode structure, eliminate confusion: